### PR TITLE
fix: pin dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,20 +7,20 @@
       "name": "speak-text",
       "license": "MIT",
       "dependencies": {
-        "@raycast/api": "^1.84.10",
-        "@raycast/utils": "^1.17.0",
-        "play-sound": "^1.1.6",
-        "ws": "^8.16.0"
+        "@raycast/api": "1.84.12",
+        "@raycast/utils": "1.18.0",
+        "play-sound": "1.1.6",
+        "ws": "8.18.0"
       },
       "devDependencies": {
-        "@raycast/eslint-config": "^1.0.11",
-        "@types/node": "20.8.10",
-        "@types/play-sound": "^1.1.2",
-        "@types/react": "18.3.3",
-        "@types/ws": "^8.5.10",
-        "eslint": "^8.57.0",
-        "prettier": "^3.3.3",
-        "typescript": "^5.4.5"
+        "@raycast/eslint-config": "1.0.11",
+        "@types/node": "22.9.0",
+        "@types/play-sound": "1.1.2",
+        "@types/react": "18.3.12",
+        "@types/ws": "8.5.13",
+        "eslint": "8.57.1",
+        "prettier": "3.3.3",
+        "typescript": "5.6.3"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
@@ -197,9 +197,9 @@
       }
     },
     "node_modules/@raycast/api": {
-      "version": "1.84.10",
-      "resolved": "https://registry.npmjs.org/@raycast/api/-/api-1.84.10.tgz",
-      "integrity": "sha512-tuRq4c3w7HA7wEVSEhyx5rK8sInhP4vIlvGTl5/naC0lUT5VaNxkNHhT71gXzyFnrrYqSDpgnKqLcdIK0lE/xg==",
+      "version": "1.84.12",
+      "resolved": "https://registry.npmjs.org/@raycast/api/-/api-1.84.12.tgz",
+      "integrity": "sha512-sFgthnRzVopNJ2DbFZZi9g7fKCRnBTlp1gJtBLuOM6mGafT+FOkUVTJKhgmxFauOHHFZ+DzAABsu8ntP/giwqQ==",
       "hasInstallScript": true,
       "dependencies": {
         "@types/node": "^20.8.10",
@@ -224,6 +224,14 @@
         "react-devtools": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@raycast/api/node_modules/@types/node": {
+      "version": "20.17.6",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.17.6.tgz",
+      "integrity": "sha512-VEI7OdvK2wP7XHnsuXbAJnEpEkF6NjSN45QJlL4VGqZSXsnicpesdTWsg9RISeSdYd3yeRj/y3k5KGjUXYnFwQ==",
+      "dependencies": {
+        "undici-types": "~6.19.2"
       }
     },
     "node_modules/@raycast/eslint-config": {
@@ -285,11 +293,12 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "20.8.10",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.8.10.tgz",
-      "integrity": "sha512-TlgT8JntpcbmKUFzjhsyhGfP2fsiz1Mv56im6enJ905xG1DAYesxJaeSbGqQmAw8OWPdhyJGhGSQGKRNJ45u9w==",
+      "version": "22.9.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.9.0.tgz",
+      "integrity": "sha512-vuyHg81vvWA1Z1ELfvLko2c8f34gyA0zaic0+Rllc5lbCnbSyuvb2Oxpm6TAUAC/2xZN3QGqxBNggD1nNR2AfQ==",
+      "dev": true,
       "dependencies": {
-        "undici-types": "~5.26.4"
+        "undici-types": "~6.19.8"
       }
     },
     "node_modules/@types/play-sound": {
@@ -307,9 +316,9 @@
       "integrity": "sha512-hCZTSvwbzWGvhqxp/RqVqwU999pBf2vp7hzIjiYOsl8wqOmUxkQ6ddw1cV3l8811+kdUFus/q4d1Y3E3SyEifA=="
     },
     "node_modules/@types/react": {
-      "version": "18.3.3",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.3.tgz",
-      "integrity": "sha512-hti/R0pS0q1/xx+TsI73XIqk26eBsISZ2R0wUijXIngRK9R/e7Xw/cXVxQK7R5JjW+SV4zGcn5hXjudkN/pLIw==",
+      "version": "18.3.12",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.12.tgz",
+      "integrity": "sha512-D2wOSq/d6Agt28q7rSI3jhU7G6aiuzljDGZ2hTZHIkrTLUI+AF3WMeKkEZ9nN2fkBAlcktT6vcZjDFiIhMYEQw==",
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.0.2"
@@ -2059,9 +2068,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "5.26.5",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
-      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="
+      "version": "6.19.8",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
+      "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw=="
     },
     "node_modules/uri-js": {
       "version": "4.4.1",

--- a/package.json
+++ b/package.json
@@ -32,26 +32,86 @@
           "required": true,
           "default": "nPczCjzI2devNBz1zQrb",
           "data": [
-            { "title": "Brian (Deep, American, Narration)", "value": "nPczCjzI2devNBz1zQrb" },
-            { "title": "Alice (Confident, British)", "value": "Xb7hH8MSUJpSbSDYk0k2" },
-            { "title": "Aria (Expressive, American)", "value": "9BWtsMINqrJLrRacOk9x" },
-            { "title": "Bill (Trustworthy, American)", "value": "pqHfZKP75CvOlQylNhV4" },
-            { "title": "Callum (Intense, Transatlantic)", "value": "N2lVS1w4EtoT3dr4eOWO" },
-            { "title": "Charlie (Natural, Australian)", "value": "IKne3meq5aSn9XLyUdCD" },
-            { "title": "Charlotte (Seductive, Swedish)", "value": "XB0fDUnXU5powFXDhCwa" },
-            { "title": "Chris (Casual, American)", "value": "iP95p4xoKVk53GoZ742B" },
-            { "title": "Daniel (Authoritative, British)", "value": "onwK4e9ZLuTAKqWW03F9" },
-            { "title": "Eric (Friendly, American)", "value": "cjVigY5qzO86Huf0OWal" },
-            { "title": "George (Warm, British)", "value": "JBFqnCBsd6RMkjVDRZzb" },
-            { "title": "Jessica (Expressive, American)", "value": "cgSgspJ2msm6clMCkdW9" },
-            { "title": "Laura (Upbeat, American)", "value": "FGY2WhTYpPnrIDTdsKH5" },
-            { "title": "Liam (Articulate, American)", "value": "TX3LPaxmHKxFdv7VOQHJ" },
-            { "title": "Lily (Warm, British)", "value": "pFZP5JQG7iQjIQuC4Bku" },
-            { "title": "Matilda (Friendly, American)", "value": "XrExE9yKIg1WjnnlVkGX" },
-            { "title": "River (Confident, American)", "value": "SAz9YHcvj6GT2YYXdXww" },
-            { "title": "Roger (Confident, American)", "value": "CwhRBWXzGAHq8TQ4Fs17" },
-            { "title": "Sarah (Soft, American)", "value": "EXAVITQu4vr4xnSDxMaL" },
-            { "title": "Will (Friendly, American)", "value": "bIHbv24MWmeRgasZH58o" }
+            {
+              "title": "Brian (Deep, American, Narration)",
+              "value": "nPczCjzI2devNBz1zQrb"
+            },
+            {
+              "title": "Alice (Confident, British)",
+              "value": "Xb7hH8MSUJpSbSDYk0k2"
+            },
+            {
+              "title": "Aria (Expressive, American)",
+              "value": "9BWtsMINqrJLrRacOk9x"
+            },
+            {
+              "title": "Bill (Trustworthy, American)",
+              "value": "pqHfZKP75CvOlQylNhV4"
+            },
+            {
+              "title": "Callum (Intense, Transatlantic)",
+              "value": "N2lVS1w4EtoT3dr4eOWO"
+            },
+            {
+              "title": "Charlie (Natural, Australian)",
+              "value": "IKne3meq5aSn9XLyUdCD"
+            },
+            {
+              "title": "Charlotte (Seductive, Swedish)",
+              "value": "XB0fDUnXU5powFXDhCwa"
+            },
+            {
+              "title": "Chris (Casual, American)",
+              "value": "iP95p4xoKVk53GoZ742B"
+            },
+            {
+              "title": "Daniel (Authoritative, British)",
+              "value": "onwK4e9ZLuTAKqWW03F9"
+            },
+            {
+              "title": "Eric (Friendly, American)",
+              "value": "cjVigY5qzO86Huf0OWal"
+            },
+            {
+              "title": "George (Warm, British)",
+              "value": "JBFqnCBsd6RMkjVDRZzb"
+            },
+            {
+              "title": "Jessica (Expressive, American)",
+              "value": "cgSgspJ2msm6clMCkdW9"
+            },
+            {
+              "title": "Laura (Upbeat, American)",
+              "value": "FGY2WhTYpPnrIDTdsKH5"
+            },
+            {
+              "title": "Liam (Articulate, American)",
+              "value": "TX3LPaxmHKxFdv7VOQHJ"
+            },
+            {
+              "title": "Lily (Warm, British)",
+              "value": "pFZP5JQG7iQjIQuC4Bku"
+            },
+            {
+              "title": "Matilda (Friendly, American)",
+              "value": "XrExE9yKIg1WjnnlVkGX"
+            },
+            {
+              "title": "River (Confident, American)",
+              "value": "SAz9YHcvj6GT2YYXdXww"
+            },
+            {
+              "title": "Roger (Confident, American)",
+              "value": "CwhRBWXzGAHq8TQ4Fs17"
+            },
+            {
+              "title": "Sarah (Soft, American)",
+              "value": "EXAVITQu4vr4xnSDxMaL"
+            },
+            {
+              "title": "Will (Friendly, American)",
+              "value": "bIHbv24MWmeRgasZH58o"
+            }
           ]
         },
         {
@@ -74,20 +134,20 @@
     }
   ],
   "dependencies": {
-    "@raycast/api": "^1.84.10",
-    "@raycast/utils": "^1.17.0",
-    "play-sound": "^1.1.6",
-    "ws": "^8.16.0"
+    "@raycast/api": "1.84.12",
+    "@raycast/utils": "1.18.0",
+    "play-sound": "1.1.6",
+    "ws": "8.18.0"
   },
   "devDependencies": {
-    "@raycast/eslint-config": "^1.0.11",
-    "@types/node": "20.8.10",
-    "@types/play-sound": "^1.1.2",
-    "@types/react": "18.3.3",
-    "eslint": "^8.57.0",
-    "prettier": "^3.3.3",
-    "typescript": "^5.4.5",
-    "@types/ws": "^8.5.10"
+    "@raycast/eslint-config": "1.0.11",
+    "@types/node": "22.9.0",
+    "@types/play-sound": "1.1.2",
+    "@types/react": "18.3.12",
+    "@types/ws": "8.5.13",
+    "eslint": "8.57.1",
+    "prettier": "3.3.3",
+    "typescript": "5.6.3"
   },
   "scripts": {
     "build": "ray build",


### PR DESCRIPTION
### TL;DR
Pin dependency versions and improve package.json formatting

### What changed?
- Removed caret (^) from dependency versions to pin exact versions
- Formatted voice options in package.json for better readability
- Updated dependencies to latest stable versions:
  - @raycast/api: 1.84.12
  - @raycast/utils: 1.18.0
  - @types/node: 22.9.0
  - @types/react: 18.3.12
  - typescript: 5.6.3
  - eslint: 8.57.1

### How to test?
1. Delete node_modules folder and package-lock.json
2. Run `npm install`
3. Verify the application builds and runs without errors
4. Test voice selection functionality remains intact

### Why make this change?
- Pinned versions ensure consistent builds across different environments
- Improved readability of voice options makes future maintenance easier
- Updated dependencies provide latest bug fixes and improvements while maintaining stability