### PR TITLE
feat: rename extension to 'ElevenLabs TTS'

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,98 +1,82 @@
-# Speak Text - A Raycast Extension
+# ElevenLabs TTS
 
-A powerful text-to-speech extension for Raycast that uses ElevenLabs' premium voices to read selected text aloud. This extension allows you to convert any selected text to natural-sounding speech with a wide variety of high-quality voices.
+Convert selected text to natural-sounding speech using ElevenLabs' premium text-to-speech voices.
 
 ## Features
 
-- 🎯 Instantly convert selected text to speech
-- 🎤 Choose from 20 premium ElevenLabs voices:
-  - Brian: Deep American voice, perfect for narration (default)
-  - Alice: Confident British voice
-  - Aria: Expressive American voice
-  - Bill: Trustworthy American voice
-  - Callum: Intense Transatlantic voice
-  - Charlie: Natural Australian voice
-  - Charlotte: Seductive Swedish voice
-  - Chris: Casual American voice
-  - Daniel: Authoritative British voice
-  - Eric: Friendly American voice
-  - George: Warm British voice
-  - Jessica: Expressive American voice
-  - Laura: Upbeat American voice
-  - Liam: Articulate American voice
-  - Lily: Warm British voice
-  - Matilda: Friendly American voice
-  - River: Confident American voice (non-binary)
-  - Roger: Confident American voice
-  - Sarah: Soft American voice
-  - Will: Friendly American voice
-- ⚡ Voice customization:
-  - Stability control (0.0-1.0)
-  - Similarity boost (0.0-1.0)
-- 🎮 Simple keyboard shortcut activation
-
-## Requirements
-
-- Raycast
-- ElevenLabs API key
-- Node.js and npm (for development)
+- Convert any selected text to speech instantly
+- Choose from 20 high-quality voices
+- Adjust voice stability and clarity
+- Real-time streaming playback
+- Simple keyboard shortcut activation
+- Stop playback anytime with Escape key
 
 ## Installation
 
-1. Clone this repository
-2. Install dependencies:
-   ```bash
-   npm install
-   ```
-3. Run the development server:
-   ```bash
-   npm run dev
-   ```
-4. Configure your ElevenLabs API key in Raycast preferences
+1. Install the extension from Raycast's store
+2. Configure your ElevenLabs API key in preferences
+3. Select your preferred voice and settings
+
+## Prerequisites
+
+- Raycast v1.50.0 or higher
+- An ElevenLabs account with API key ([Get one here](https://elevenlabs.io))
+- macOS 10.15 or higher
+
+## Getting Started
+
+1. Get your ElevenLabs API key:
+
+   - Sign up/login at [ElevenLabs](https://elevenlabs.io)
+   - Go to your Profile Settings
+   - Copy your API key
+
+2. Configure the extension in Raycast preferences (⌘,):
+   - Paste your ElevenLabs API key
+   - Choose your preferred voice
+   - Adjust stability and similarity boost settings (optional)
 
 ## Usage
 
 1. Select any text in any application
-2. Trigger the extension using your chosen Raycast keyboard shortcut
-3. The selected text will be read aloud using your preferred voice settings
+2. Trigger the extension (default: ⌥ D)
+3. The selected text will be read aloud
+4. Press Escape to stop playback
 
-## Configuration
+## Voice Settings
 
-Configure the extension in Raycast preferences:
+### Stability (0.0-1.0)
 
-- **ElevenLabs API Key**: Your API key from ElevenLabs
-- **Voice**: Choose from 20 different voices (Brian is default)
-- **Stability**: Control voice consistency (0.0-1.0)
-  - Higher values: More stable, consistent voice
-  - Lower values: More expressive, variable voice
-- **Similarity Boost**: Control voice clarity (0.0-1.0)
-  - Higher values: Clearer, more precise voice
-  - Lower values: More natural-sounding voice
+Controls how stable/consistent the voice will be:
 
-## Development
+- Higher values (0.7-1.0): More consistent, good for formal content
+- Lower values (0.0-0.3): More expressive, good for casual content
+- Default: 0.5 (balanced)
 
-This extension is built with:
+### Similarity Boost (0.0-1.0)
 
-- React and TypeScript
-- Raycast Extensions API
-- ElevenLabs Text-to-Speech API
-- play-sound for audio playback
+Controls voice clarity and naturalness:
 
-## Technical Details
-
-The extension:
-
-1. Captures selected text using Raycast's API
-2. Converts text to speech using ElevenLabs' API
-3. Saves the audio temporarily
-4. Plays the audio using play-sound
-5. Automatically cleans up temporary files
+- Higher values (0.7-1.0): Clearer, more precise pronunciation
+- Lower values (0.0-0.3): More natural-sounding, with subtle variations
+- Default: 0.75 (clear but natural)
 
 ## Credits
 
-- Built with [Raycast Extensions API](https://developers.raycast.com)
-- Voice synthesis by [ElevenLabs](https://elevenlabs.io)
+This extension uses:
 
-## License
+- [ElevenLabs API](https://elevenlabs.io) for text-to-speech conversion
+- [Raycast API](https://developers.raycast.com) for the extension framework
 
-MIT License - feel free to modify and reuse this extension as you please!
+## Support
+
+For issues and feature requests, please [create an issue](https://github.com/raycast/extensions/issues) in the Raycast extensions repository.
+
+## Privacy
+
+This extension:
+
+- Only processes text that you explicitly select
+- Sends selected text to ElevenLabs for speech synthesis
+- Does not store any data locally
+- Does not collect any analytics

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,10 +1,10 @@
 {
-  "name": "speak-text",
+  "name": "elevenlabs-tts",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "speak-text",
+      "name": "elevenlabs-tts",
       "license": "MIT",
       "dependencies": {
         "@raycast/api": "1.84.12",

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "$schema": "https://www.raycast.com/schemas/extension.json",
-  "name": "speak-text",
-  "title": "Speak Text",
-  "description": "Speak selected text using ElevenLabs' premium text-to-speech voices",
+  "name": "elevenlabs-tts",
+  "title": "ElevenLabs TTS",
+  "description": "Convert selected text to lifelike speech using ElevenLabs' premium AI voices",
   "icon": "extension-icon.png",
   "author": "lachie_james",
   "categories": [


### PR DESCRIPTION
### TL;DR

Rebranded the extension from "Speak Text" to "ElevenLabs TTS" with improved documentation and clearer setup instructions.

### What changed?

- Renamed extension to "ElevenLabs TTS"
- Rewrote README with clearer organization and structure
- Added detailed voice settings documentation
- Included privacy information and support details
- Updated package metadata with new name and description

### How to test?

1. Check that the extension name appears as "ElevenLabs TTS" in Raycast
2. Verify all documentation links work correctly
3. Confirm the setup instructions are clear and accurate
4. Test that the voice settings descriptions match actual behavior

### Why make this change?

The rebranding and documentation improvements make the extension more professional and user-friendly. The new name better reflects its integration with ElevenLabs, while the enhanced documentation helps users understand the setup process and voice customization options more clearly.