### PR TITLE
fix: add more README instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,15 +20,20 @@ Convert selected text to natural-sounding speech using ElevenLabs' premium text-
 ## Prerequisites
 
 - Raycast v1.50.0 or higher
-- An ElevenLabs account with API key ([Get one here](https://elevenlabs.io))
 - macOS 10.15 or higher
+- An ElevenLabs account with API key ([Get one here](https://elevenlabs.io))
 
 ## Getting Started
 
 1. Get your ElevenLabs API key:
 
-   - Sign up/login at [ElevenLabs](https://elevenlabs.io)
-   - Go to your Profile Settings
+   - Create an account at [elevenlabs.io](https://elevenlabs.io)
+   - Go to your [API Keys](https://elevenlabs.io/app/settings/api-keys)
+   - Click "Create API Key"
+   - (Optional) Set the key name to something like "Raycast TTS"
+   - (Optional) Click "Restrict Key" and enable only the permissions needed for this extension:
+     - ✅ Text to Speech
+     - ❌ All other permissions
    - Copy your API key
 
 2. Configure the extension in Raycast preferences (⌘,):

--- a/src/services/elevenlabs/config.ts
+++ b/src/services/elevenlabs/config.ts
@@ -48,4 +48,4 @@ export function createStreamConfig(text: string, settings: VoiceSettings): Eleve
       stream_chunk_size: 8192, // Optimal size for smooth streaming
     },
   };
-} 
+}

--- a/src/services/elevenlabs/streaming.ts
+++ b/src/services/elevenlabs/streaming.ts
@@ -125,4 +125,4 @@ export async function streamElevenLabsAudio(
       }
     });
   });
-} 
+}

--- a/src/services/elevenlabs/websocket.ts
+++ b/src/services/elevenlabs/websocket.ts
@@ -13,4 +13,4 @@ export function setupWebSocket(url: string, apiKey: string): WebSocket {
   return new WebSocket(url, {
     headers: { "xi-api-key": apiKey },
   });
-} 
+}

--- a/src/speak-selected.tsx
+++ b/src/speak-selected.tsx
@@ -83,4 +83,4 @@ export default async function Command() {
       title: `❌ ${error instanceof Error ? error.message : "Unknown error"}`,
     });
   }
-} 
+}

--- a/src/types/preferences.ts
+++ b/src/types/preferences.ts
@@ -16,4 +16,4 @@ export interface Preferences {
 export interface VoiceSettings {
   stability: number; // Higher values = more consistent voice
   similarity_boost: number; // Higher values = clearer but potentially less natural
-} 
+}

--- a/src/utils/audio.ts
+++ b/src/utils/audio.ts
@@ -1,3 +1,3 @@
 import player from "play-sound";
 
-export const audioPlayer = player({}); 
+export const audioPlayer = player({});

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -14,4 +14,4 @@ export function getErrorMessage(error: Error): string {
     return "No internet connection - Please check your network and try again";
   }
   return `ElevenLabs error: ${error.message}`;
-} 
+}

--- a/src/utils/text.ts
+++ b/src/utils/text.ts
@@ -63,4 +63,4 @@ export async function validateSelectedText(): Promise<string> {
     }
     throw error;
   }
-} 
+}


### PR DESCRIPTION
### TL;DR
Enhanced API key setup instructions in README.md with clearer steps and security recommendations.

### What changed?
- Added specific navigation steps to access API keys section
- Included optional steps for key naming and permission restrictions
- Reorganized prerequisites section for better readability
- Updated the ElevenLabs signup link to be more specific

### How to test?
1. Follow the updated README instructions to create a new API key
2. Verify you can navigate to the API Keys section using the provided link
3. Confirm the permission restriction steps work as described
4. Test that the API key works with the extension after following these steps

### Why make this change?
To provide users with more detailed and secure API key setup instructions, helping them properly configure the extension while following security best practices by limiting API key permissions to only what's necessary.