### PR TITLE
fix: remove 'play-sound' dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,6 @@
       "dependencies": {
         "@raycast/api": "1.84.12",
         "@raycast/utils": "1.18.0",
-        "play-sound": "1.1.6",
         "ws": "8.18.0"
       },
       "devDependencies": {
@@ -1202,14 +1201,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/find-exec": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/find-exec/-/find-exec-1.0.3.tgz",
-      "integrity": "sha512-gnG38zW90mS8hm5smNcrBnakPEt+cGJoiMkJwCU0IYnEb0H2NQk0NIljhNW+48oniCriFek/PH6QXbwsJo/qug==",
-      "dependencies": {
-        "shell-quote": "^1.8.1"
-      }
-    },
     "node_modules/find-up": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
@@ -1734,14 +1725,6 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
-    "node_modules/play-sound": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/play-sound/-/play-sound-1.1.6.tgz",
-      "integrity": "sha512-09eO4QiXNFXJffJaOW5P6x6F5RLihpLUkXttvUZeWml0fU6x6Zp7AjG9zaeMpgH2ZNvq4GR1ytB22ddYcqJIZA==",
-      "dependencies": {
-        "find-exec": "1.0.3"
-      }
-    },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -1895,14 +1878,6 @@
       "dev": true,
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/shell-quote": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.1.tgz",
-      "integrity": "sha512-6j1W9l1iAs/4xYBI1SYOVZyFcCis9b4KCLQ8fgAGG07QvzaRLVVRQvAy85yNmmZSjYjg4MWh4gNvlPujU/5LpA==",
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/signal-exit": {

--- a/package.json
+++ b/package.json
@@ -136,7 +136,6 @@
   "dependencies": {
     "@raycast/api": "1.84.12",
     "@raycast/utils": "1.18.0",
-    "play-sound": "1.1.6",
     "ws": "8.18.0"
   },
   "devDependencies": {


### PR DESCRIPTION
### TL;DR
Replaced the `play-sound` npm package with native macOS `afplay` command for audio playback.

### What changed?
- Removed `play-sound` and its dependencies from package.json
- Implemented a new `playAudio` function using Node's `spawn` to call macOS's built-in `afplay` command
- Updated the audio streaming logic to use the new playback implementation
- Improved error handling and cleanup of temporary audio files

### How to test?
1. Select text in any application
2. Trigger the Raycast command to speak the selected text
3. Verify that audio playback works correctly
4. Test error scenarios by using invalid audio files or interrupting playback

### Why make this change?
Using the native `afplay` command instead of a third-party package reduces dependencies and provides more reliable audio playback on macOS. This change also improves error handling and ensures proper cleanup of temporary files.