### PR TITLE
fix: add more comments

### DIFF
--- a/src/speak-selected.tsx
+++ b/src/speak-selected.tsx
@@ -189,13 +189,28 @@ export class AudioManager extends EventEmitter {
     if (!this.ws) return;
 
     // Create configuration with optimized chunk settings
+    // For more info, see: https://elevenlabs.io/docs/api-reference/websockets
     const config: ElevenLabsConfig = {
       text: this.config.text,
       voice_settings: this.config.settings,
       generation_config: {
-        // Use progressive chunk sizes for better initial latency
+        // chunk_length_schedule determines when audio generation is triggered based on buffer size
+        // Each number represents the minimum characters needed before generating the next audio chunk
+        // [120, 160, 250, 290] means:
+        // - First chunk: Wait for 120 characters
+        // - Second chunk: Wait for additional 160 characters
+        // - Third chunk: Wait for additional 250 characters
+        // - Fourth and beyond: Wait for additional 290 characters each time
+        // Lower values = faster response but potentially lower quality
+        // Higher values = better quality but increased latency
+        // Values should be between 50-500 characters
         chunk_length_schedule: [120, 160, 250, 290],
-        // 8KB chunks provide good balance of performance and memory usage
+
+        // stream_chunk_size controls the size of each audio chunk sent back from the server
+        // 8KB (8192 bytes) is the recommended size that balances:
+        // - Network efficiency (not too many small packets)
+        // - Memory usage (not too large to buffer)
+        // - Playback smoothness (consistent chunk size for steady streaming)
         stream_chunk_size: 8192,
       },
     };


### PR DESCRIPTION
### TL;DR
Added detailed documentation for ElevenLabs WebSocket streaming configuration parameters.

### What changed?
Added comprehensive inline comments explaining the `chunk_length_schedule` and `stream_chunk_size` parameters in the ElevenLabs WebSocket configuration. The comments detail how the chunking system works, recommended value ranges, and the tradeoffs between latency, quality, and performance.

### How to test?
1. Review the added documentation for accuracy against the ElevenLabs API documentation
2. Verify the existing configuration values align with the documented recommendations
3. Test audio streaming to confirm the documented behavior matches actual performance

### Why make this change?
To improve code maintainability by documenting the reasoning behind the chosen configuration values and help future developers understand the performance implications of modifying these parameters. The added documentation references official ElevenLabs documentation and explains the tradeoffs between different configuration values.