### PR TITLE
security: bump cross-spawn to 7.0.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2212,9 +2212,9 @@
       }
     },
     "node_modules/cross-spawn": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
       "dev": true,
       "dependencies": {
         "path-key": "^3.1.0",


### PR DESCRIPTION
lachiejames@MacBookPro raycast-elevenlabs-tts % npm i  

up to date, audited 410 packages in 625ms

67 packages are looking for funding
  run `npm fund` for details

1 high severity vulnerability

To address all issues, run:
  npm audit fix

Run `npm audit` for details.

lachiejames@MacBookPro raycast-elevenlabs-tts % npm audit fix

changed 1 package, and audited 410 packages in 840ms

67 packages are looking for funding
  run `npm fund` for details

found 0 vulnerabilities