### PR TITLE
refactor: use auto-generated Raycast preference types

### DIFF
--- a/src/speak-selected.tsx
+++ b/src/speak-selected.tsx
@@ -1,6 +1,5 @@
 import { showToast, Toast, getPreferenceValues, getSelectedText } from "@raycast/api";
 import { AudioManager } from "./audio/AudioManager";
-import { Preferences } from "./voice/types";
 import { prepareVoiceSettings } from "./voice/settings";
 import { validateSelectedText } from "./text/validation";
 import { getTextStats } from "./text/processing";
@@ -47,7 +46,7 @@ export default async function Command() {
     const { wordCount } = getTextStats(selectedText);
     const previewText = getTextPreview(selectedText);
 
-    const preferences = getPreferenceValues<Preferences>();
+    const preferences = getPreferenceValues<Preferences.SpeakSelected>();
     const settings = prepareVoiceSettings(preferences);
 
     await showToast({

--- a/src/voice/settings.test.ts
+++ b/src/voice/settings.test.ts
@@ -2,11 +2,11 @@ import { prepareVoiceSettings } from "./settings";
 
 describe("prepareVoiceSettings", () => {
   it("should handle valid preference values", () => {
-    const prefs = {
+    const prefs: Preferences.SpeakSelected = {
       stability: "0.7",
       similarityBoost: "0.8",
       elevenLabsApiKey: "dummy",
-      voiceId: "dummy",
+      voiceId: "nPczCjzI2devNBz1zQrb",
     };
 
     const settings = prepareVoiceSettings(prefs);
@@ -15,11 +15,11 @@ describe("prepareVoiceSettings", () => {
   });
 
   it("should clamp values above 1", () => {
-    const prefs = {
+    const prefs: Preferences.SpeakSelected = {
       stability: "1.5",
       similarityBoost: "2.0",
       elevenLabsApiKey: "dummy",
-      voiceId: "dummy",
+      voiceId: "nPczCjzI2devNBz1zQrb",
     };
 
     const settings = prepareVoiceSettings(prefs);
@@ -28,11 +28,11 @@ describe("prepareVoiceSettings", () => {
   });
 
   it("should clamp values below 0", () => {
-    const prefs = {
+    const prefs: Preferences.SpeakSelected = {
       stability: "-0.5",
       similarityBoost: "-1.0",
       elevenLabsApiKey: "dummy",
-      voiceId: "dummy",
+      voiceId: "nPczCjzI2devNBz1zQrb",
     };
 
     const settings = prepareVoiceSettings(prefs);
@@ -41,11 +41,11 @@ describe("prepareVoiceSettings", () => {
   });
 
   it("should handle invalid number strings", () => {
-    const prefs = {
+    const prefs: Preferences.SpeakSelected = {
       stability: "invalid",
       similarityBoost: "not a number",
       elevenLabsApiKey: "dummy",
-      voiceId: "dummy",
+      voiceId: "nPczCjzI2devNBz1zQrb",
     };
 
     const settings = prepareVoiceSettings(prefs);

--- a/src/voice/settings.ts
+++ b/src/voice/settings.ts
@@ -1,4 +1,4 @@
-import { Preferences, VoiceSettings } from "./types";
+import { VoiceSettings } from "./types";
 
 /**
  * Prepares voice settings from user preferences
@@ -7,7 +7,7 @@ import { Preferences, VoiceSettings } from "./types";
  * @param preferences - User-configured preferences from Raycast
  * @returns Normalized voice settings
  */
-export function prepareVoiceSettings(preferences: Preferences): VoiceSettings {
+export function prepareVoiceSettings(preferences: Preferences.SpeakSelected): VoiceSettings {
   return {
     stability: Math.min(1, Math.max(0, parseFloat(preferences.stability) || 0.5)),
     similarity_boost: Math.min(1, Math.max(0, parseFloat(preferences.similarityBoost) || 0.75)),

--- a/src/voice/types.ts
+++ b/src/voice/types.ts
@@ -1,15 +1,4 @@
 /**
- * Preferences configurable through Raycast's UI
- * These settings affect voice generation quality and characteristics
- */
-export interface Preferences {
-  elevenLabsApiKey: string; // API key from ElevenLabs dashboard
-  voiceId: string; // Selected voice identifier
-  stability: string; // Voice stability (0.0-1.0)
-  similarityBoost: string; // Voice clarity enhancement (0.0-1.0)
-}
-
-/**
  * Voice generation settings passed to ElevenLabs API
  * Controls the characteristics of the generated speech
  */


### PR DESCRIPTION
Relates to https://github.com/raycast/extensions/pull/15992#discussion_r1901624335

## Changes
- Removed manual `Preferences` interface from `types.ts` in favor of auto-generated types from `raycast-env.d.ts`
- Updated preference type annotations to use `Preferences.SpeakSelected` namespace
- Simplified imports by removing redundant preference type

## Motivation
The Raycast framework auto-generates preference types in `raycast-env.d.ts` based on the extension's manifest. This change removes duplicate type definitions and uses the official typing system, improving type safety and maintainability.

## Testing
- Verified that all preference values are correctly typed and accessible
- Confirmed that voice settings are properly parsed from preferences
- Ensured existing functionality continues to work as expected