### PR TITLE
fix: check file exists before cleanup

### DIFF
--- a/src/audio/AudioManager.ts
+++ b/src/audio/AudioManager.ts
@@ -1,6 +1,6 @@
 import { spawn } from "child_process";
 import { EventEmitter } from "events";
-import { promises as fs } from "node:fs";
+import { promises as fs, existsSync } from "node:fs";
 import { tmpdir } from "os";
 import { join } from "path/posix";
 import { WebSocket, Data } from "ws";
@@ -329,7 +329,7 @@ export class AudioManager extends EventEmitter {
    */
   private async cleanup(): Promise<void> {
     try {
-      await fs.unlink(this.tempFile);
+      if (existsSync(this.tempFile)) await fs.unlink(this.tempFile);
       console.log("Temporary file cleaned up");
     } catch (error) {
       console.error("Cleanup error:", error);


### PR DESCRIPTION
### TL;DR
Added existence check before deleting temporary audio files

### What changed?
Added a file existence check using `existsSync` before attempting to delete temporary audio files in the cleanup process. The `unlink` operation will now only execute if the target file exists.

### How to test?
1. Run the audio manager with a temporary file
2. Verify cleanup succeeds when file exists
3. Verify no errors occur when file is already deleted or doesn't exist
4. Check logs to confirm proper cleanup behavior

### Why make this change?
Prevents unnecessary errors from being thrown when attempting to delete non-existent temporary files. This makes the cleanup process more robust and eliminates spurious error messages in the logs when the file has already been removed or never existed.

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/wtZm1qGubkICEGksgEjQ/00270c4f-2727-4456-90c5-571e16c1cc36.png)

