### PR TITLE
feat: Allow speed control for TTS playback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Raycast ElevenLabs TTS Changelog
 
+## 1.1.0 - 2025-01-19
+
+### Added
+- Playback speed control with options from 0.5x to 2.0x speed
+- New preferences dropdown for playback speed selection
+- Integration with macOS afplay command for speed-adjusted playback
+
 ## 1.0.0 - 2024-12-21
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://www.raycast.com/schemas/extension.json",
   "name": "elevenlabs-tts",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "title": "ElevenLabs TTS",
   "description": "Convert selected text to lifelike speech using ElevenLabs' premium AI voices",
   "icon": "extension-icon.png",
@@ -130,6 +130,44 @@
           "type": "textfield",
           "required": false,
           "default": "0.75"
+        },
+        {
+          "name": "playbackSpeed",
+          "title": "Playback Speed",
+          "description": "Speed of speech playback",
+          "type": "dropdown",
+          "required": true,
+          "default": "1.00",
+          "data": [
+            {
+              "title": "0.5x (Slow)",
+              "value": "0.50"
+            },
+            {
+              "title": "0.75x (Slower)",
+              "value": "0.75"
+            },
+            {
+              "title": "1.0x (Normal)",
+              "value": "1.00"
+            },
+            {
+              "title": "1.25x (Faster)",
+              "value": "1.25"
+            },
+            {
+              "title": "1.5x (Fast)",
+              "value": "1.50"
+            },
+            {
+              "title": "1.75x (Very Fast)",
+              "value": "1.75"
+            },
+            {
+              "title": "2.0x (Fastest)",
+              "value": "2.00"
+            }
+          ]
         }
       ]
     }

--- a/src/audio/AudioManager.ts
+++ b/src/audio/AudioManager.ts
@@ -5,6 +5,7 @@ import { tmpdir } from "os";
 import { join } from "path/posix";
 import { WebSocket, Data } from "ws";
 import { StreamConfig, WSMessage, ElevenLabsConfig } from "./types";
+import { validatePlaybackSpeed } from "../voice/settings";
 
 /**
  * Manages the audio streaming and playback process
@@ -254,7 +255,9 @@ export class AudioManager extends EventEmitter {
   private async playAudioFile(): Promise<void> {
     return new Promise((resolve, reject) => {
       // Use macOS native audio player for reliable playback
-      const process = spawn("afplay", [this.tempFile]);
+      // Use -r flag to control playback rate
+      const validatedSpeed = validatePlaybackSpeed(this.config.playbackSpeed);
+      const process = spawn("afplay", ["-r", validatedSpeed, this.tempFile]);
 
       // Handle process errors (e.g., afplay not found)
       process.on("error", (error) => {

--- a/src/audio/types.ts
+++ b/src/audio/types.ts
@@ -33,4 +33,5 @@ export interface StreamConfig {
   voiceId: string;
   apiKey: string;
   settings: VoiceSettings;
+  playbackSpeed: string; // Speed multiplier for audio playback (0.5-2.0)
 }

--- a/src/speak-selected.tsx
+++ b/src/speak-selected.tsx
@@ -59,6 +59,7 @@ export default async function Command() {
       voiceId: preferences.voiceId,
       apiKey: preferences.elevenLabsApiKey,
       settings,
+      playbackSpeed: preferences.playbackSpeed,
     });
 
     await showToast({

--- a/src/voice/settings.test.ts
+++ b/src/voice/settings.test.ts
@@ -1,4 +1,4 @@
-import { prepareVoiceSettings } from "./settings";
+import { prepareVoiceSettings, validatePlaybackSpeed } from "./settings";
 
 describe("prepareVoiceSettings", () => {
   it("should handle valid preference values", () => {
@@ -7,6 +7,7 @@ describe("prepareVoiceSettings", () => {
       similarityBoost: "0.8",
       elevenLabsApiKey: "dummy",
       voiceId: "nPczCjzI2devNBz1zQrb",
+      playbackSpeed: "1.00",
     };
 
     const settings = prepareVoiceSettings(prefs);
@@ -20,6 +21,7 @@ describe("prepareVoiceSettings", () => {
       similarityBoost: "2.0",
       elevenLabsApiKey: "dummy",
       voiceId: "nPczCjzI2devNBz1zQrb",
+      playbackSpeed: "1.00",
     };
 
     const settings = prepareVoiceSettings(prefs);
@@ -33,6 +35,7 @@ describe("prepareVoiceSettings", () => {
       similarityBoost: "-1.0",
       elevenLabsApiKey: "dummy",
       voiceId: "nPczCjzI2devNBz1zQrb",
+      playbackSpeed: "1.00",
     };
 
     const settings = prepareVoiceSettings(prefs);
@@ -46,10 +49,35 @@ describe("prepareVoiceSettings", () => {
       similarityBoost: "not a number",
       elevenLabsApiKey: "dummy",
       voiceId: "nPczCjzI2devNBz1zQrb",
+      playbackSpeed: "1.00",
     };
 
     const settings = prepareVoiceSettings(prefs);
     expect(settings.stability).toBe(0.5); // default value
     expect(settings.similarity_boost).toBe(0.75); // default value
+  });
+});
+
+describe("validatePlaybackSpeed", () => {
+  it("should handle valid speed values", () => {
+    expect(validatePlaybackSpeed("1.0")).toBe("1.00");
+    expect(validatePlaybackSpeed("1.5")).toBe("1.50");
+    expect(validatePlaybackSpeed("0.75")).toBe("0.75");
+  });
+
+  it("should clamp values above 2.0", () => {
+    expect(validatePlaybackSpeed("2.5")).toBe("2.00");
+    expect(validatePlaybackSpeed("3.0")).toBe("2.00");
+  });
+
+  it("should clamp values below 0.5", () => {
+    expect(validatePlaybackSpeed("0.25")).toBe("0.50");
+    expect(validatePlaybackSpeed("0.1")).toBe("0.50");
+  });
+
+  it("should handle invalid speed values", () => {
+    expect(validatePlaybackSpeed("invalid")).toBe("1.00");
+    expect(validatePlaybackSpeed("fast")).toBe("1.00");
+    expect(validatePlaybackSpeed("")).toBe("1.00");
   });
 });

--- a/src/voice/settings.ts
+++ b/src/voice/settings.ts
@@ -1,6 +1,17 @@
 import { VoiceSettings } from "./types";
 
 /**
+ * Validates and normalizes playback speed
+ * Ensures speed is between 0.5 and 2.0, defaulting to 1.0 if invalid
+ */
+export function validatePlaybackSpeed(speed: string): string {
+  const parsed = parseFloat(speed);
+  if (isNaN(parsed)) return "1.00";
+  const clamped = Math.min(2.0, Math.max(0.5, parsed));
+  return clamped.toFixed(2);
+}
+
+/**
  * Prepares voice settings from user preferences
  * Converts string values to numbers and applies safety bounds
  *


### PR DESCRIPTION
Proof this works: https://www.loom.com/share/8a6f1c143ea048048212d4ca0c8e9ff8

### TL;DR
Added playback speed control for text-to-speech audio output

### What changed?
- Added a new playback speed dropdown setting with options ranging from 0.5x to 2.0x
- Integrated playback speed control with the macOS `afplay` command using the `-r` flag
- Extended the stream configuration to support playback speed parameter

### How to test?
1. Open preferences and select a playback speed from the dropdown
2. Select text and trigger the speak command
3. Verify that the audio plays at the selected speed
4. Try different speed settings (0.5x for slow, 2.0x for fastest) to ensure proper playback

### Why make this change?
To provide users with flexibility in controlling the speech rate, allowing them to consume content faster or slower based on their preferences and needs. This is particularly useful for users who prefer to speed through content or those who need slower playback for better comprehension.